### PR TITLE
SOCD revamp (#57)

### DIFF
--- a/HAL/avr/avr_nousb/include/core/KeyboardMode.hpp
+++ b/HAL/avr/avr_nousb/include/core/KeyboardMode.hpp
@@ -8,7 +8,7 @@
 
 class KeyboardMode : public InputMode {
   public:
-    KeyboardMode(socd::SocdType socd_type);
+    KeyboardMode();
     ~KeyboardMode();
     void SendReport(InputState &inputs);
 

--- a/HAL/avr/avr_nousb/src/core/KeyboardMode.cpp
+++ b/HAL/avr/avr_nousb/src/core/KeyboardMode.cpp
@@ -2,7 +2,7 @@
 
 #include "core/InputMode.hpp"
 
-KeyboardMode::KeyboardMode(socd::SocdType socd_type) : InputMode(socd_type) {}
+KeyboardMode::KeyboardMode() {}
 
 KeyboardMode::~KeyboardMode() {}
 

--- a/HAL/avr/avr_usb/include/core/KeyboardMode.hpp
+++ b/HAL/avr/avr_usb/include/core/KeyboardMode.hpp
@@ -9,7 +9,7 @@
 
 class KeyboardMode : public InputMode {
   public:
-    KeyboardMode(socd::SocdType socd_type);
+    KeyboardMode();
     ~KeyboardMode();
     void SendReport(InputState &inputs);
 

--- a/HAL/avr/avr_usb/src/core/KeyboardMode.cpp
+++ b/HAL/avr/avr_usb/src/core/KeyboardMode.cpp
@@ -4,7 +4,7 @@
 
 #include <ArduinoKeyboard.hpp>
 
-KeyboardMode::KeyboardMode(socd::SocdType socd_type) : InputMode(socd_type) {}
+KeyboardMode::KeyboardMode() {}
 
 KeyboardMode::~KeyboardMode() {
     _keyboard.releaseAll();

--- a/HAL/pico/include/core/KeyboardMode.hpp
+++ b/HAL/pico/include/core/KeyboardMode.hpp
@@ -9,7 +9,7 @@
 
 class KeyboardMode : public InputMode {
   public:
-    KeyboardMode(socd::SocdType socd_type);
+    KeyboardMode();
     ~KeyboardMode();
     void SendReport(InputState &inputs);
 

--- a/HAL/pico/src/core/KeyboardMode.cpp
+++ b/HAL/pico/src/core/KeyboardMode.cpp
@@ -4,7 +4,7 @@
 
 #include <TUKeyboard.hpp>
 
-KeyboardMode::KeyboardMode(socd::SocdType socd_type) : InputMode(socd_type) {
+KeyboardMode::KeyboardMode() {
     _keyboard = new TUKeyboard();
     _keyboard->begin();
 }

--- a/config/mode_selection.hpp
+++ b/config/mode_selection.hpp
@@ -49,7 +49,7 @@ void select_mode(CommunicationBackend *backend) {
         } else if (inputs.down) {
             set_mode(backend, new Ultimate(socd::SOCD_2IP));
         } else if (inputs.right) {
-            set_mode(backend, new FgcMode(socd::SOCD_NEUTRAL));
+            set_mode(backend, new FgcMode(socd::SOCD_NEUTRAL, socd::SOCD_NEUTRAL));
         } else if (inputs.b) {
             set_mode(backend, new RivalsOfAether(socd::SOCD_2IP));
         }

--- a/include/core/ControllerMode.hpp
+++ b/include/core/ControllerMode.hpp
@@ -7,7 +7,7 @@
 
 class ControllerMode : public InputMode {
   public:
-    ControllerMode(socd::SocdType socd_type);
+    ControllerMode();
     void UpdateOutputs(InputState &inputs, OutputState &outputs);
     void ResetDirections();
     virtual void UpdateDirections(

--- a/include/core/InputMode.hpp
+++ b/include/core/InputMode.hpp
@@ -6,15 +6,12 @@
 
 class InputMode {
   public:
-    InputMode(socd::SocdType socd_type);
+    InputMode();
     virtual ~InputMode();
 
   protected:
     socd::SocdPair *_socd_pairs = nullptr;
     size_t _socd_pair_count = 0;
-    /* Exposed to child classes so that game modes are able to have different behaviour depending on
-     * SOCD cleaning mode. */
-    socd::SocdType _socd_type;
 
     virtual void HandleSocd(InputState &inputs);
 

--- a/include/core/socd.hpp
+++ b/include/core/socd.hpp
@@ -5,17 +5,19 @@
 #include "stdlib.hpp"
 
 namespace socd {
-
     typedef enum {
         SOCD_NEUTRAL,
         SOCD_2IP,
         SOCD_2IP_NO_REAC,
-        SOCD_KEYBOARD,
+        SOCD_DIR1_PRIORITY,
+        SOCD_DIR2_PRIORITY,
+        SOCD_NONE,
     } SocdType;
 
     typedef struct {
         bool InputState::*input_dir1;
         bool InputState::*input_dir2;
+        SocdType socd_type = SOCD_NEUTRAL;
     } SocdPair;
 
     typedef struct {
@@ -25,12 +27,17 @@ namespace socd {
         bool lock_dir2 = false;
     } SocdState;
 
-    void twoIPNoReactivate(bool &input_dir1, bool &input_dir2, SocdState &socd_state);
+    void second_input_priority_no_reactivation(
+        bool &input_dir1,
+        bool &input_dir2,
+        SocdState &socd_state
+    );
 
-    void twoIP(bool &input_dir1, bool &input_dir2, SocdState &socd_state);
+    void second_input_priority(bool &input_dir1, bool &input_dir2, SocdState &socd_state);
 
     void neutral(bool &input_dir1, bool &input_dir2);
 
+    void dir1_priority(bool &input_dir1, bool &input_dir2);
 }
 
 #endif

--- a/include/modes/FgcMode.hpp
+++ b/include/modes/FgcMode.hpp
@@ -7,10 +7,9 @@
 
 class FgcMode : public ControllerMode {
   public:
-    FgcMode(socd::SocdType socd_type);
+    FgcMode(socd::SocdType horizontal_socd, socd::SocdType vertical_socd);
 
   private:
-    void HandleSocd(InputState &inputs);
     void UpdateDigitalOutputs(InputState &inputs, OutputState &outputs);
     void UpdateAnalogOutputs(InputState &inputs, OutputState &outputs);
 };

--- a/src/core/ControllerMode.cpp
+++ b/src/core/ControllerMode.cpp
@@ -1,6 +1,6 @@
 #include "core/ControllerMode.hpp"
 
-ControllerMode::ControllerMode(socd::SocdType socd_type) : InputMode(socd_type) {
+ControllerMode::ControllerMode() {
     // Set up initial state.
     ResetDirections();
 }

--- a/src/core/InputMode.cpp
+++ b/src/core/InputMode.cpp
@@ -3,9 +3,7 @@
 #include "core/socd.hpp"
 #include "core/state.hpp"
 
-InputMode::InputMode(socd::SocdType socd_type) {
-    _socd_type = socd_type;
-}
+InputMode::InputMode() {}
 
 InputMode::~InputMode() {
     delete[] _socd_pairs;
@@ -25,21 +23,31 @@ void InputMode::HandleSocd(InputState &inputs) {
     // Handle SOCD resolution for each SOCD button pair.
     for (size_t i = 0; i < _socd_pair_count; i++) {
         socd::SocdPair pair = _socd_pairs[i];
-        switch (_socd_type) {
+        switch (pair.socd_type) {
             case socd::SOCD_NEUTRAL:
                 socd::neutral(inputs.*(pair.input_dir1), inputs.*(pair.input_dir2));
                 break;
             case socd::SOCD_2IP:
-                socd::twoIP(inputs.*(pair.input_dir1), inputs.*(pair.input_dir2), _socd_states[i]);
-                break;
-            case socd::SOCD_2IP_NO_REAC:
-                socd::twoIPNoReactivate(
+                socd::second_input_priority(
                     inputs.*(pair.input_dir1),
                     inputs.*(pair.input_dir2),
                     _socd_states[i]
                 );
                 break;
-            case socd::SOCD_KEYBOARD:
+            case socd::SOCD_2IP_NO_REAC:
+                socd::second_input_priority_no_reactivation(
+                    inputs.*(pair.input_dir1),
+                    inputs.*(pair.input_dir2),
+                    _socd_states[i]
+                );
+                break;
+            case socd::SOCD_DIR1_PRIORITY:
+                socd::dir1_priority(inputs.*(pair.input_dir1), inputs.*(pair.input_dir2));
+                break;
+            case socd::SOCD_DIR2_PRIORITY:
+                socd::dir1_priority(inputs.*(pair.input_dir2), inputs.*(pair.input_dir1));
+                break;
+            case socd::SOCD_NONE:
                 break;
         }
     }

--- a/src/core/socd.cpp
+++ b/src/core/socd.cpp
@@ -1,6 +1,10 @@
 #include "core/socd.hpp"
 
-void socd::twoIPNoReactivate(bool &input_dir1, bool &input_dir2, SocdState &socd_state) {
+void socd::second_input_priority_no_reactivation(
+    bool &input_dir1,
+    bool &input_dir2,
+    SocdState &socd_state
+) {
     bool is_dir1 = false;
     bool is_dir2 = false;
     if (input_dir1 && input_dir2) {
@@ -39,7 +43,7 @@ void socd::twoIPNoReactivate(bool &input_dir1, bool &input_dir2, SocdState &socd
     input_dir2 = is_dir2;
 }
 
-void socd::twoIP(bool &input_dir1, bool &input_dir2, SocdState &socd_state) {
+void socd::second_input_priority(bool &input_dir1, bool &input_dir2, SocdState &socd_state) {
     bool is_dir1 = false;
     bool is_dir2 = false;
     if (input_dir1 && socd_state.was_dir2) {
@@ -67,16 +71,14 @@ void socd::twoIP(bool &input_dir1, bool &input_dir2, SocdState &socd_state) {
 }
 
 void socd::neutral(bool &input_dir1, bool &input_dir2) {
-    bool is_dir1 = false;
-    bool is_dir2 = false;
-    if (!input_dir1 && input_dir2) {
-        is_dir1 = false;
-        is_dir2 = true;
+    if (input_dir1 && input_dir2) {
+        input_dir1 = false;
+        input_dir2 = false;
     }
-    if (input_dir1 && !input_dir2) {
-        is_dir1 = true;
-        is_dir2 = false;
+}
+
+void socd::dir1_priority(bool &input_dir1, bool &input_dir2) {
+    if (input_dir1 && input_dir2) {
+        input_dir2 = false;
     }
-    input_dir1 = is_dir1;
-    input_dir2 = is_dir2;
 }

--- a/src/modes/DefaultKeyboardMode.cpp
+++ b/src/modes/DefaultKeyboardMode.cpp
@@ -3,7 +3,7 @@
 #include "core/socd.hpp"
 #include "core/state.hpp"
 
-DefaultKeyboardMode::DefaultKeyboardMode(socd::SocdType socd_type) : KeyboardMode(socd_type) {}
+DefaultKeyboardMode::DefaultKeyboardMode(socd::SocdType socd_type) {}
 
 void DefaultKeyboardMode::UpdateKeys(InputState &inputs) {
     Press(HID_KEY_A, inputs.l);

--- a/src/modes/FgcMode.cpp
+++ b/src/modes/FgcMode.cpp
@@ -1,17 +1,17 @@
 #include "modes/FgcMode.hpp"
 
-FgcMode::FgcMode(socd::SocdType socd_type) : ControllerMode(socd_type) {
-    _socd_pair_count = 1;
+FgcMode::FgcMode(socd::SocdType horizontal_socd, socd::SocdType vertical_socd) {
+    _socd_pair_count = 4;
     _socd_pairs = new socd::SocdPair[_socd_pair_count]{
-        socd::SocdPair{&InputState::left, &InputState::right},
+        socd::SocdPair{&InputState::left,   &InputState::right, horizontal_socd         },
+ /* Mod X override C-Up input if both are pressed. Without this, neutral SOCD doesn't work
+  properly if Down and both Up buttons are pressed, because it first resolves Down + Mod X
+  to set both as unpressed, and then it sees C-Up as pressed but not Down, so you get an up
+  input instead of neutral. */
+        socd::SocdPair{ &InputState::mod_x, &InputState::c_up,  socd::SOCD_DIR1_PRIORITY},
+        socd::SocdPair{ &InputState::down,  &InputState::mod_x, vertical_socd           },
+        socd::SocdPair{ &InputState::down,  &InputState::c_up,  vertical_socd           },
     };
-}
-
-void FgcMode::HandleSocd(InputState &inputs) {
-    if (inputs.down && (inputs.mod_x || inputs.c_up)) {
-        inputs.down = false;
-    }
-    InputMode::HandleSocd(inputs);
 }
 
 void FgcMode::UpdateDigitalOutputs(InputState &inputs, OutputState &outputs) {

--- a/src/modes/Melee18Button.cpp
+++ b/src/modes/Melee18Button.cpp
@@ -4,14 +4,13 @@
 #define ANALOG_STICK_NEUTRAL 128
 #define ANALOG_STICK_MAX 208
 
-Melee18Button::Melee18Button(socd::SocdType socd_type, Melee18ButtonOptions options)
-    : ControllerMode(socd_type) {
+Melee18Button::Melee18Button(socd::SocdType socd_type, Melee18ButtonOptions options) {
     _socd_pair_count = 4;
     _socd_pairs = new socd::SocdPair[_socd_pair_count]{
-        socd::SocdPair{&InputState::left,    &InputState::right  },
-        socd::SocdPair{ &InputState::down,   &InputState::up     },
-        socd::SocdPair{ &InputState::c_left, &InputState::c_right},
-        socd::SocdPair{ &InputState::c_down, &InputState::c_up   },
+        socd::SocdPair{&InputState::left,    &InputState::right,   socd_type},
+        socd::SocdPair{ &InputState::down,   &InputState::up,      socd_type},
+        socd::SocdPair{ &InputState::c_left, &InputState::c_right, socd_type},
+        socd::SocdPair{ &InputState::c_down, &InputState::c_up,    socd_type},
     };
 
     _options = options;

--- a/src/modes/Melee20Button.cpp
+++ b/src/modes/Melee20Button.cpp
@@ -4,14 +4,13 @@
 #define ANALOG_STICK_NEUTRAL 128
 #define ANALOG_STICK_MAX 208
 
-Melee20Button::Melee20Button(socd::SocdType socd_type, Melee20ButtonOptions options)
-    : ControllerMode(socd_type) {
+Melee20Button::Melee20Button(socd::SocdType socd_type, Melee20ButtonOptions options) {
     _socd_pair_count = 4;
     _socd_pairs = new socd::SocdPair[_socd_pair_count]{
-        socd::SocdPair{&InputState::left,    &InputState::right  },
-        socd::SocdPair{ &InputState::down,   &InputState::up     },
-        socd::SocdPair{ &InputState::c_left, &InputState::c_right},
-        socd::SocdPair{ &InputState::c_down, &InputState::c_up   },
+        socd::SocdPair{&InputState::left,    &InputState::right,   socd_type},
+        socd::SocdPair{ &InputState::down,   &InputState::up,      socd_type},
+        socd::SocdPair{ &InputState::c_left, &InputState::c_right, socd_type},
+        socd::SocdPair{ &InputState::c_down, &InputState::c_up,    socd_type},
     };
 
     _options = options;

--- a/src/modes/ProjectM.cpp
+++ b/src/modes/ProjectM.cpp
@@ -4,13 +4,13 @@
 #define ANALOG_STICK_NEUTRAL 128
 #define ANALOG_STICK_MAX 228
 
-ProjectM::ProjectM(socd::SocdType socd_type, ProjectMOptions options) : ControllerMode(socd_type) {
+ProjectM::ProjectM(socd::SocdType socd_type, ProjectMOptions options) {
     _socd_pair_count = 4;
     _socd_pairs = new socd::SocdPair[_socd_pair_count]{
-        socd::SocdPair{&InputState::left,    &InputState::right  },
-        socd::SocdPair{ &InputState::down,   &InputState::up     },
-        socd::SocdPair{ &InputState::c_left, &InputState::c_right},
-        socd::SocdPair{ &InputState::c_down, &InputState::c_up   },
+        socd::SocdPair{&InputState::left,    &InputState::right,   socd_type},
+        socd::SocdPair{ &InputState::down,   &InputState::up,      socd_type},
+        socd::SocdPair{ &InputState::c_left, &InputState::c_right, socd_type},
+        socd::SocdPair{ &InputState::c_down, &InputState::c_up,    socd_type},
     };
 
     _options = options;

--- a/src/modes/RivalsOfAether.cpp
+++ b/src/modes/RivalsOfAether.cpp
@@ -4,13 +4,13 @@
 #define ANALOG_STICK_NEUTRAL 128
 #define ANALOG_STICK_MAX 228
 
-RivalsOfAether::RivalsOfAether(socd::SocdType socd_type) : ControllerMode(socd_type) {
+RivalsOfAether::RivalsOfAether(socd::SocdType socd_type) {
     _socd_pair_count = 4;
     _socd_pairs = new socd::SocdPair[_socd_pair_count]{
-        socd::SocdPair{&InputState::left,    &InputState::right  },
-        socd::SocdPair{ &InputState::down,   &InputState::up     },
-        socd::SocdPair{ &InputState::c_left, &InputState::c_right},
-        socd::SocdPair{ &InputState::c_down, &InputState::c_up   },
+        socd::SocdPair{&InputState::left,    &InputState::right,   socd_type},
+        socd::SocdPair{ &InputState::down,   &InputState::up,      socd_type},
+        socd::SocdPair{ &InputState::c_left, &InputState::c_right, socd_type},
+        socd::SocdPair{ &InputState::c_down, &InputState::c_up,    socd_type},
     };
 }
 

--- a/src/modes/Ultimate.cpp
+++ b/src/modes/Ultimate.cpp
@@ -5,13 +5,13 @@
 #define ANALOG_STICK_NEUTRAL 128
 #define ANALOG_STICK_MAX 228
 
-Ultimate::Ultimate(socd::SocdType socd_type) : ControllerMode(socd_type) {
+Ultimate::Ultimate(socd::SocdType socd_type) {
     _socd_pair_count = 4;
     _socd_pairs = new socd::SocdPair[_socd_pair_count]{
-        socd::SocdPair{&InputState::left,    &InputState::right  },
-        socd::SocdPair{ &InputState::down,   &InputState::up     },
-        socd::SocdPair{ &InputState::c_left, &InputState::c_right},
-        socd::SocdPair{ &InputState::c_down, &InputState::c_up   },
+        socd::SocdPair{&InputState::left,    &InputState::right,   socd_type},
+        socd::SocdPair{ &InputState::down,   &InputState::up,      socd_type},
+        socd::SocdPair{ &InputState::c_left, &InputState::c_right, socd_type},
+        socd::SocdPair{ &InputState::c_down, &InputState::c_up,    socd_type},
     };
 }
 

--- a/src/modes/extra/DarkSouls.cpp
+++ b/src/modes/extra/DarkSouls.cpp
@@ -4,13 +4,13 @@
 #define ANALOG_STICK_NEUTRAL 128
 #define ANALOG_STICK_MAX 255
 
-DarkSouls::DarkSouls(socd::SocdType socd_type) : ControllerMode(socd_type) {
+DarkSouls::DarkSouls(socd::SocdType socd_type) {
     _socd_pair_count = 4;
     _socd_pairs = new socd::SocdPair[_socd_pair_count]{
-        socd::SocdPair{&InputState::left,    &InputState::right  },
-        socd::SocdPair{ &InputState::down,   &InputState::mod_x  },
-        socd::SocdPair{ &InputState::c_left, &InputState::c_right},
-        socd::SocdPair{ &InputState::c_down, &InputState::c_up   },
+        socd::SocdPair{&InputState::left,    &InputState::right,   socd_type},
+        socd::SocdPair{ &InputState::down,   &InputState::mod_x,   socd_type},
+        socd::SocdPair{ &InputState::c_left, &InputState::c_right, socd_type},
+        socd::SocdPair{ &InputState::c_down, &InputState::c_up,    socd_type},
     };
 }
 

--- a/src/modes/extra/HollowKnight.cpp
+++ b/src/modes/extra/HollowKnight.cpp
@@ -4,13 +4,13 @@
 #define ANALOG_STICK_NEUTRAL 128
 #define ANALOG_STICK_MAX 255
 
-HollowKnight::HollowKnight(socd::SocdType socd_type) : ControllerMode(socd_type) {
+HollowKnight::HollowKnight(socd::SocdType socd_type) {
     _socd_pair_count = 4;
     _socd_pairs = new socd::SocdPair[_socd_pair_count]{
-        socd::SocdPair{&InputState::left,    &InputState::right  },
-        socd::SocdPair{ &InputState::down,   &InputState::mod_x  },
-        socd::SocdPair{ &InputState::c_left, &InputState::c_right},
-        socd::SocdPair{ &InputState::c_down, &InputState::c_up   },
+        socd::SocdPair{&InputState::left,    &InputState::right,   socd_type},
+        socd::SocdPair{ &InputState::down,   &InputState::mod_x,   socd_type},
+        socd::SocdPair{ &InputState::c_left, &InputState::c_right, socd_type},
+        socd::SocdPair{ &InputState::c_down, &InputState::c_up,    socd_type},
     };
 }
 

--- a/src/modes/extra/MKWii.cpp
+++ b/src/modes/extra/MKWii.cpp
@@ -4,13 +4,13 @@
 #define ANALOG_STICK_NEUTRAL 128
 #define ANALOG_STICK_MAX 255
 
-MKWii::MKWii(socd::SocdType socd_type) : ControllerMode(socd_type) {
+MKWii::MKWii(socd::SocdType socd_type) {
     _socd_pair_count = 4;
     _socd_pairs = new socd::SocdPair[_socd_pair_count]{
-        socd::SocdPair{&InputState::left, &InputState::right},
-        socd::SocdPair{ &InputState::l,   &InputState::down },
-        socd::SocdPair{ &InputState::l,   &InputState::mod_x},
-        socd::SocdPair{ &InputState::l,   &InputState::mod_y},
+        socd::SocdPair{&InputState::left, &InputState::right, socd_type},
+        socd::SocdPair{ &InputState::l,   &InputState::down,  socd_type},
+        socd::SocdPair{ &InputState::l,   &InputState::mod_x, socd_type},
+        socd::SocdPair{ &InputState::l,   &InputState::mod_y, socd_type},
     };
 }
 

--- a/src/modes/extra/MultiVersus.cpp
+++ b/src/modes/extra/MultiVersus.cpp
@@ -4,13 +4,13 @@
 #define ANALOG_STICK_NEUTRAL 128
 #define ANALOG_STICK_MAX 255
 
-MultiVersus::MultiVersus(socd::SocdType socd_type) : ControllerMode(socd_type) {
+MultiVersus::MultiVersus(socd::SocdType socd_type) {
     _socd_pair_count = 4;
     _socd_pairs = new socd::SocdPair[_socd_pair_count]{
-        socd::SocdPair{&InputState::left,    &InputState::right  },
-        socd::SocdPair{ &InputState::down,   &InputState::up     },
-        socd::SocdPair{ &InputState::c_left, &InputState::c_right},
-        socd::SocdPair{ &InputState::c_down, &InputState::c_up   },
+        socd::SocdPair{&InputState::left,    &InputState::right,   socd_type},
+        socd::SocdPair{ &InputState::down,   &InputState::up,      socd_type},
+        socd::SocdPair{ &InputState::c_left, &InputState::c_right, socd_type},
+        socd::SocdPair{ &InputState::c_down, &InputState::c_up,    socd_type},
     };
 }
 

--- a/src/modes/extra/RocketLeague.cpp
+++ b/src/modes/extra/RocketLeague.cpp
@@ -4,20 +4,14 @@
 #define ANALOG_STICK_NEUTRAL 128
 #define ANALOG_STICK_MAX 255
 
-RocketLeague::RocketLeague(socd::SocdType socd_type) : ControllerMode(socd_type) {
-    _socd_pair_count = 3;
+RocketLeague::RocketLeague(socd::SocdType socd_type) {
+    _socd_pair_count = 4;
     _socd_pairs = new socd::SocdPair[_socd_pair_count]{
-        socd::SocdPair{&InputState::left,    &InputState::right  },
-        socd::SocdPair{ &InputState::c_left, &InputState::c_right},
-        socd::SocdPair{ &InputState::c_down, &InputState::c_up   },
+        socd::SocdPair{&InputState::left,    &InputState::right,   socd_type               },
+        socd::SocdPair{ &InputState::down,   &InputState::mod_x,   socd::SOCD_DIR2_PRIORITY},
+        socd::SocdPair{ &InputState::c_left, &InputState::c_right, socd_type               },
+        socd::SocdPair{ &InputState::c_down, &InputState::c_up,    socd_type               },
     };
-}
-
-void RocketLeague::HandleSocd(InputState &inputs) {
-    if (inputs.mod_x && inputs.down) {
-        inputs.down = false;
-    }
-    InputMode::HandleSocd(inputs);
 }
 
 void RocketLeague::UpdateDigitalOutputs(InputState &inputs, OutputState &outputs) {

--- a/src/modes/extra/SaltAndSanctuary.cpp
+++ b/src/modes/extra/SaltAndSanctuary.cpp
@@ -4,13 +4,13 @@
 #define ANALOG_STICK_NEUTRAL 128
 #define ANALOG_STICK_MAX 255
 
-SaltAndSanctuary::SaltAndSanctuary(socd::SocdType socd_type) : ControllerMode(socd_type) {
+SaltAndSanctuary::SaltAndSanctuary(socd::SocdType socd_type) {
     _socd_pair_count = 4;
     _socd_pairs = new socd::SocdPair[_socd_pair_count]{
-        socd::SocdPair{&InputState::left,    &InputState::right  },
-        socd::SocdPair{ &InputState::down,   &InputState::mod_x  },
-        socd::SocdPair{ &InputState::c_left, &InputState::c_right},
-        socd::SocdPair{ &InputState::c_down, &InputState::c_up   },
+        socd::SocdPair{&InputState::left,    &InputState::right,   socd_type},
+        socd::SocdPair{ &InputState::down,   &InputState::mod_x,   socd_type},
+        socd::SocdPair{ &InputState::c_left, &InputState::c_right, socd_type},
+        socd::SocdPair{ &InputState::c_down, &InputState::c_up,    socd_type},
     };
 }
 

--- a/src/modes/extra/ShovelKnight.cpp
+++ b/src/modes/extra/ShovelKnight.cpp
@@ -4,13 +4,13 @@
 #define ANALOG_STICK_NEUTRAL 128
 #define ANALOG_STICK_MAX 255
 
-ShovelKnight::ShovelKnight(socd::SocdType socd_type) : ControllerMode(socd_type) {
+ShovelKnight::ShovelKnight(socd::SocdType socd_type) {
     _socd_pair_count = 4;
     _socd_pairs = new socd::SocdPair[_socd_pair_count]{
-        socd::SocdPair{&InputState::left,    &InputState::right  },
-        socd::SocdPair{ &InputState::down,   &InputState::mod_x  },
-        socd::SocdPair{ &InputState::c_left, &InputState::c_right},
-        socd::SocdPair{ &InputState::c_down, &InputState::c_up   },
+        socd::SocdPair{&InputState::left,    &InputState::right,   socd_type},
+        socd::SocdPair{ &InputState::down,   &InputState::mod_x,   socd_type},
+        socd::SocdPair{ &InputState::c_left, &InputState::c_right, socd_type},
+        socd::SocdPair{ &InputState::c_down, &InputState::c_up,    socd_type},
     };
 }
 

--- a/src/modes/extra/ToughLoveArena.cpp
+++ b/src/modes/extra/ToughLoveArena.cpp
@@ -1,9 +1,9 @@
 #include "modes/extra/ToughLoveArena.hpp"
 
-ToughLoveArena::ToughLoveArena(socd::SocdType socd_type) : KeyboardMode(socd_type) {
+ToughLoveArena::ToughLoveArena(socd::SocdType socd_type) {
     _socd_pair_count = 1;
     _socd_pairs = new socd::SocdPair[_socd_pair_count]{
-        socd::SocdPair{&InputState::left, &InputState::right},
+        socd::SocdPair{&InputState::left, &InputState::right, socd_type},
     };
 }
 

--- a/src/modes/extra/Ultimate2.cpp
+++ b/src/modes/extra/Ultimate2.cpp
@@ -5,13 +5,13 @@
 #define ANALOG_STICK_NEUTRAL 128
 #define ANALOG_STICK_MAX 228
 
-Ultimate2::Ultimate2(socd::SocdType socd_type) : ControllerMode(socd_type) {
+Ultimate2::Ultimate2(socd::SocdType socd_type) {
     _socd_pair_count = 4;
     _socd_pairs = new socd::SocdPair[_socd_pair_count]{
-        socd::SocdPair{&InputState::left,    &InputState::right  },
-        socd::SocdPair{ &InputState::down,   &InputState::up     },
-        socd::SocdPair{ &InputState::c_left, &InputState::c_right},
-        socd::SocdPair{ &InputState::c_down, &InputState::c_up   },
+        socd::SocdPair{&InputState::left,    &InputState::right,   socd_type},
+        socd::SocdPair{ &InputState::down,   &InputState::up,      socd_type},
+        socd::SocdPair{ &InputState::c_left, &InputState::c_right, socd_type},
+        socd::SocdPair{ &InputState::c_down, &InputState::c_up,    socd_type},
     };
 }
 


### PR DESCRIPTION
* feat: SOCD cleaning rework

socd_type is no longer a required parameter of InputMode. Instead, a SocdType is included as part of each SocdPair, allowing SOCD resolution method to be defined per-axis without the need to override HandleSocd().

New SOCD resolution methods SOCD_DIR1_PRIORITY and SOCD_DIR2_PRIORITY have been added, which was made possible by the above change. These would previously not have been useful, without the ability to define SocdType per SocdPair.

The constructor of FgcMode now accepts two parameters, horizontal_socd and vertical_socd, which can be used to set the SOCD resolution method for the horizontal and vertical axes separately.

The default vertical SOCD resolution for FgcMode is now neutral, due to this being a requirement in some rulesets. This can easily be changed by passing socd::SOCD_DIR2_PRIORITY as the second argument to the constructor in mode_selection.hpp.

* fix: correct function names