### PR TITLE
reset loopTime detect if poll rate increases too

### DIFF
--- a/HAL/avr/src/comms/GamecubeBackend.cpp
+++ b/HAL/avr/src/comms/GamecubeBackend.cpp
@@ -127,7 +127,8 @@ void GamecubeBackend::SendReport() {
         _data.report.left = _outputs.triggerLAnalog + 31;
         _data.report.right = _outputs.triggerRAnalog + 31;
     } else {
-        if(loopTime > minLoop+(minLoop >> 1)) {//if the loop time is 50% longer than expected
+        //if the loop time is greater than 150% expected or lesser than 75% expected
+        if(loopTime > minLoop + (minLoop >> 1) || loopTime < minLoop - (minLoop >> 2)) {
             /*
             Serial.println("Loop time too long?");
             Serial.print("Loop time: ");

--- a/HAL/pico/src/comms/GamecubeBackend.cpp
+++ b/HAL/pico/src/comms/GamecubeBackend.cpp
@@ -177,7 +177,8 @@ void GamecubeBackend::SendReport() {
                 _report.r_analog = _outputs.triggerRAnalog;
             }
         }
-        if(loopTime > minLoop+(minLoop >> 1)) {//if the loop time is 50% longer than expected
+        //if the loop time is greater than 150% expected or lesser than 75% expected
+        if(loopTime > minLoop + (minLoop >> 1) || loopTime < minLoop - (minLoop >> 2)) {
             detect = true;//stop scanning inputs briefly and re-measure timings
             loopCount = 0;
             sampleCount = 1;


### PR DESCRIPTION
loopTime detect is already reset if poll rate decreases. This should catch the increase in poll rate from ~60hz (HBC/Nintendont) to ~120hz (Melee)

this should fix the bug regarding Wii reset encountered by Zuppy at Nouns Bowl https://old.reddit.com/r/SSBM/comments/1kcwdhl/daily_discussion_thread_may_02_2025_upcoming/mq9o782/