### PR TITLE
Updated platformio.ini to fix linker error when building for pico

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -57,7 +57,7 @@ lib_deps =
 	https://github.com/JonnyHaystack/ArduinoKeyboard/archive/refs/tags/1.0.5.zip
 
 [arduino_pico_base]
-platform = https://github.com/maxgerhardt/platform-raspberrypi
+platform = https://github.com/maxgerhardt/platform-raspberrypi.git#5e87ae34ca025274df25b3303e9e9cb6c120123c
 framework = arduino
 board = pico
 extra_scripts = pre:builder_scripts/arduino_pico.py


### PR DESCRIPTION
Update platformio.ini to fix linker error when building for pico.
Fixes an incompatibility between platform version and Arduino-Pico version by referencing the older Arduino-Pico version in the platformio.ini

See this  [issue](https://github.com/maxgerhardt/platform-raspberrypi/issues/75#issuecomment-2381371700)